### PR TITLE
set `tasty-discover` as an extra-dep in the example

### DIFF
--- a/tasty-discover-example/stack.yaml
+++ b/tasty-discover-example/stack.yaml
@@ -4,6 +4,7 @@ packages:
 - location:
     git: "https://github.com/lwm/tasty-discover.git"
     commit: "HEAD"
+  extra-dep: true
 extra-deps:
 - "tasty-th-0.1.4"
 flags: {}


### PR DESCRIPTION
This would prevent tests or benchmarks for `tasty-discover` from running when calling `stack test` etc and only do it for the example
