### PR TITLE
README: fix statement about test file locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ Inside this file, add the following:
 ```
 
 Create a test file inside `test/`. `tasty-discover` can detect test files in
-whatever directory structure you choose (as long as they sit under your
-`hs-source-dirs`), so there is no restrictions on directory organization.
+whatever directory structure you choose (as long as they sit in the same directory as the `Tasty.hs` file created above or any subdirectory thereof), so there is no restrictions on directory organization.
 However, you must end your test file names with `Test.hs`. So, for example,
 `EatYourLandlordTest.hs` would be a perfectly acceptable test file name.
 


### PR DESCRIPTION
`hs-source-dirs` may contain multiple directories, which are not subdirectories of each other. For example, the following is perfectly fine:

```
hs-source-dirs: tests/ anotherTestDir/
```

`tasty-discover` will not find tests in `anotherTestDir` (if  `Tasty.hs` is in `tests/Tasty.hs`), so the previous statement about the location of tests was wrong.
