### PR TITLE
Use Haskell naming conventions

### DIFF
--- a/integration-test/test-configurable-module/FooMySuffix.hs
+++ b/integration-test/test-configurable-module/FooMySuffix.hs
@@ -1,4 +1,4 @@
 module FooMySuffix where
 
-prop_beast :: Bool
-prop_beast = 666 == (666 :: Integer)
+prop_theNumberOfTheBeast :: Bool
+prop_theNumberOfTheBeast = 666 == (666 :: Integer)

--- a/integration-test/test-configurable-module/Nested/BarMySuffix.hs
+++ b/integration-test/test-configurable-module/Nested/BarMySuffix.hs
@@ -1,4 +1,4 @@
 module Nested.BarMySuffix where
 
-prop_life :: Bool
-prop_life = 42 == (42 :: Integer)
+prop_theMeaningOfLife :: Bool
+prop_theMeaningOfLife = 42 == (42 :: Integer)

--- a/tasty-discover-example/test/AllTheFolders/AnotherNestTest.hs
+++ b/tasty-discover-example/test/AllTheFolders/AnotherNestTest.hs
@@ -1,4 +1,4 @@
 module AllTheFolders.AnotherNestTest where
 
-prop_nine_is_nine :: Bool
-prop_nine_is_nine = 9 == (9 :: Integer)
+prop_nineIsNine :: Bool
+prop_nineIsNine = 9 == (9 :: Integer)

--- a/tasty-discover-example/test/FooTest.hs
+++ b/tasty-discover-example/test/FooTest.hs
@@ -2,8 +2,8 @@ module FooTest where
 
 import Test.Tasty.Discover (Assertion, (@?=))
 
-case_the_answer :: Assertion
-case_the_answer = 42 @?= (42 :: Integer)
+case_theAnswer :: Assertion
+case_theAnswer = 42 @?= (42 :: Integer)
 
-case_the_number_of_the_beast :: Assertion
-case_the_number_of_the_beast = 666 @?= (666 :: Integer)
+case_theNumberOfTheBeast :: Assertion
+case_theNumberOfTheBeast = 666 @?= (666 :: Integer)

--- a/tasty-discover-example/test/Thing/AnotherThing/NestedTest.hs
+++ b/tasty-discover-example/test/Thing/AnotherThing/NestedTest.hs
@@ -1,4 +1,4 @@
 module Thing.AnotherThing.NestedTest where
 
-prop_two_is_two :: Bool
-prop_two_is_two = 2 == (2 :: Integer)
+prop_twoIsTwo :: Bool
+prop_twoIsTwo = 2 == (2 :: Integer)

--- a/test/ParseTest.hs
+++ b/test/ParseTest.hs
@@ -6,26 +6,26 @@ import           Test.Tasty.Discover (Assertion,
                                       Config (Config, configModuleSuffix),
                                       parseConfig, (@?=))
 
-case_parse_config :: Assertion
-case_parse_config =
+case_parseConfig :: Assertion
+case_parseConfig =
     parseConfig "foo" ["--module-suffix=MySuffix"]
     @?=
     Right Config {configModuleSuffix=Just "MySuffix"}
 
-case_parse_config_missing_arg :: Assertion
-case_parse_config_missing_arg =
+case_parseConfigMissingArg :: Assertion
+case_parseConfigMissingArg =
     parseConfig "foo" ["--module-suffix"]
     @?=
     Left "foo: option `--module-suffix' requires an argument SUFFIX\n"
 
-case_parse_config_empty_arg :: Assertion
-case_parse_config_empty_arg =
+case_parseConfigEmptyArg :: Assertion
+case_parseConfigEmptyArg =
     parseConfig "foo" []
     @?=
     Right (Config Nothing)
 
-case_parse_config_invalid_arg :: Assertion
-case_parse_config_invalid_arg =
+case_parseConfigInvalidArg :: Assertion
+case_parseConfigInvalidArg =
     parseConfig "foo" ["a"]
     @?=
     Left "foo: unexpected argument `a`\n"


### PR DESCRIPTION
Too much python these days ...
