### PR TITLE
Add test group example

### DIFF
--- a/tasty-discover-example/test/FooTest.hs
+++ b/tasty-discover-example/test/FooTest.hs
@@ -1,6 +1,12 @@
 module FooTest where
 
-import Test.Tasty.Discover (Assertion, (@?=))
+import Test.Tasty.Discover (Assertion, (@?=), TestTree, testCase)
+
+test_allMyTestsGrouped :: [TestTree]
+test_allMyTestsGrouped =
+    [ testCase "Testing the meaning of life." case_theAnswer
+    , testCase "Testing the number of the beast." case_theNumberOfTheBeast
+    ]
 
 case_theAnswer :: Assertion
 case_theAnswer = 42 @?= (42 :: Integer)


### PR DESCRIPTION
Closes #20.

Added a test group in [tasty-discover-example/test/FooTest.hs](https://github.com/lwm/tasty-discover/blob/1bf11c60f1d16e7b807470ec5350b3fb0b23120b/tasty-discover-example/test/FooTest.hs#L5-L9). 

`tasty-discover` picks it up and reports it correctly. Resulting report looks like:

```
tasty-discover
  nineIsNine:                         OK
    +++ OK, passed 100 tests.
  theAnswer:                          OK
  theNumberOfTheBeast:                OK
  allMyTestsGrouped
    Testing the meaning of life.:     OK
    Testing the number of the beast.: OK
  twoIsTwo:                           OK
    +++ OK, passed 100 tests.
```
