### PR TITLE
[WIP] Integrate doctests into test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ script:
 - stack install --no-terminal tasty-discover
 - make test
 - make hlint
+- make doctest

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ STACK_TEST:=stack test --pedantic
 unit_test:
 	$(STACK_TEST) tasty-discover:unit-tests
 
+doctest:
+	stack test tasty-discover:doctest
+
 integration_test:
 	cd $(INTEGRATION_DIR) \
 	&& $(STACK_TEST) tasty-discover-integration-test:configurable-suffix \
@@ -18,7 +21,7 @@ example_test:
 	&& $(STACK_TEST) example:example-test \
 	&& cd -
 
-test: unit_test integration_test example_test
+test: unit_test integration_test example_test doctest
 
 hlint:
 	hlint src/ test/
@@ -27,4 +30,4 @@ hlint_refactor:
 	find src/ test/ -name "*.hs" \
 	-exec hlint --refactor --refactor-options -i {} \;
 
-.PHONY: unit_test integration_test example_test test hlint hlint_refactor
+.PHONY: unit_test integration_test example_test test hlint hlint_refactor doctest

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "ignore": ["Main.hs"],
+  "sourceFolders": ["src/Test/Tasty"]
+}

--- a/tasty-discover.cabal
+++ b/tasty-discover.cabal
@@ -71,6 +71,17 @@ test-suite unit-tests
     , tasty-discover
   default-language:    Haskell2010
 
+test-suite doctest
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     src/Test/Tasty/
+  main-is:            Doctest.hs
+  build-depends:
+      base == 4.*
+    , tasty-discover
+    , doctest
+    , doctest-discover
+  default-language:   Haskell2010
+
 Source-repository head
   type:     git
   location: git://github.com/lwm/tasty-discover.git


### PR DESCRIPTION
Closes #7.

Work in progress so far. I still need to write the actual doctests but the cabal configuration is complete. Found a nice stack command on the way: `stack test tasty-discover:doctests`
