### PR TITLE
Travis clean up based on Stack/Travis docs. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-sudo: required
+# Partially robbed from: https://docs.haskellstack.org/en/stable/travis_ci/
+
+sudo: false
 
 language: haskell
 
@@ -6,10 +8,6 @@ ghc:
 - 7.8.4
 - 7.10.3
 - 8.0.1
-
-branches:
-  only:
-    - master
 
 cache:
   directories:
@@ -21,10 +19,8 @@ before_install:
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 install:
-- stack --no-terminal setup
-- stack --no-terminal install hlint
+- stack install hlint tasty-discover
 
 script:
-- stack install --no-terminal tasty-discover
 - make test
 - make hlint

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ROOT_DIR:=.
 INTEGRATION_DIR:=./integration-test/
 EXAMPLE_DIR:=./example/
 
-STACK_TEST:=stack test --pedantic
+STACK_TEST:=stack test --no-terminal --haddock --no-haddock-deps
 
 unit_test:
 	$(STACK_TEST) tasty-discover:unit-tests

--- a/tasty-discover.cabal
+++ b/tasty-discover.cabal
@@ -66,6 +66,7 @@ test-suite unit-tests
   main-is:             Tasty.hs
   other-modules:
     ParseTest
+    UtilTest
   build-depends:
       base == 4.*
     , tasty-discover


### PR DESCRIPTION
I wanted to use the `doc/travis-complex.yml` but it's really too much. So, I stick with `language: haskell` and `ghc: x,y,z`. Closes #44 and #45.
