### PR TITLE
Deprecate `case_` for `unit_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog] and this project adheres to
 [Keep a Changelog]: http://keepachangelog.com/
 [Semantic Versioning]: http://semver.org/
 
+# 3.0.0 [UNRELEASED]
+
+### Changed
+- [#97]: `case_` is deprecated in favour of `unit_` for HUnit test cases.
+
+[#97]: https://github.com/lwm/tasty-discover/pull/97
+
 # 2.0.3 [2017-04-13]
 
 ### Fixed

--- a/library/Test/Tasty/Generator.hs
+++ b/library/Test/Tasty/Generator.hs
@@ -54,6 +54,7 @@ showSetup t var = "  " ++ var ++ " <- " ++ setup ++ "\n"
 generators :: [Generator]
 generators =
   [ quickCheckPropertyGenerator
+  , hunitTestCaseGeneratorDeprecated
   , hunitTestCaseGenerator
   , hspecTestCaseGenerator
   , tastyTestGroupGenerator
@@ -67,9 +68,29 @@ quickCheckPropertyGenerator = Generator
   , generatorSetup  = \t -> "pure $ QC.testProperty \"" ++ name t ++ "\" " ++ qualifyFunction t
   }
 
+deprecationMessage :: String
+deprecationMessage =
+  error $ concat
+    [ "\n\n"
+    , "----------------------------------------------------------\n"
+    , "DEPRECATION NOTICE: The `case_` prefix is deprecated.\n"
+    , "Please use the `unit_` prefix instead.\n"
+    , "Please see https://github.com/lwm/tasty-discover/issues/95.\n"
+    , "----------------------------------------------------------\n"
+    ]
+
+-- DEPRECATED: Use `unit_` instead (below)
+hunitTestCaseGeneratorDeprecated :: Generator
+hunitTestCaseGeneratorDeprecated = Generator
+  { generatorPrefix = "case_"
+  , generatorImport = deprecationMessage
+  , generatorClass  = deprecationMessage
+  , generatorSetup  = const deprecationMessage
+  }
+
 hunitTestCaseGenerator :: Generator
 hunitTestCaseGenerator = Generator
-  { generatorPrefix = "case_"
+  { generatorPrefix = "unit_"
   , generatorImport = "import qualified Test.Tasty.HUnit as HU\n"
   , generatorClass  = concat
     [ "class TestCase a where testCase :: String -> a -> IO T.TestTree\n"

--- a/library/Test/Tasty/Generator.hs
+++ b/library/Test/Tasty/Generator.hs
@@ -37,13 +37,19 @@ name = chooser '_' ' ' . tail . dropWhile (/= '_') . testFunction
   where chooser c1 c2 = map $ \c3 -> if c3 == c1 then c2 else c3
 
 getGenerator :: Test -> Generator
-getGenerator t = fromJust $ find ((`isPrefixOf` testFunction t) . generatorPrefix) generators
+getGenerator t = fromJust $ getPrefix generators
+  where getPrefix = find ((`isPrefixOf` testFunction t) . generatorPrefix)
 
 getGenerators :: [Test] -> [Generator]
-getGenerators = map head . groupBy  ((==) `on` generatorPrefix) . sortOn generatorPrefix . map getGenerator
+getGenerators =
+  map head .
+  groupBy  ((==) `on` generatorPrefix) .
+  sortOn generatorPrefix .
+  map getGenerator
 
 showSetup :: Test -> String -> String
-showSetup t var = "  " ++ var ++ " <- " ++ generatorSetup (getGenerator t) t ++ "\n"
+showSetup t var = "  " ++ var ++ " <- " ++ setup ++ "\n"
+  where setup = generatorSetup (getGenerator t) t
 
 generators :: [Generator]
 generators =

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: "tasty-discover"
-version: "2.0.3"
+version: "3.0.0"
 synopsis: "Test discovery for the tasty framework."
 description: >
   Automatic test discovery and runner for the tasty framework.

--- a/tasty-discover.cabal
+++ b/tasty-discover.cabal
@@ -3,7 +3,7 @@
 -- see: https://github.com/sol/hpack
 
 name:           tasty-discover
-version:        2.0.3
+version:        3.0.0
 synopsis:       Test discovery for the tasty framework.
 description:    Automatic test discovery and runner for the tasty framework.
                 Prefix your test case names and tasty-discover will discover, collect and run them. All popular test libraries are covered. Configure once and then just write your tests. Avoid forgetting to add test modules to your Cabal/Hpack files. Tasty ingredients are included along with various configuration options for different use cases. Please see the `README.md` below for how to get started.

--- a/test/ConfigTest.hs
+++ b/test/ConfigTest.hs
@@ -6,22 +6,22 @@ import           Test.Tasty.Discover  (findTests, generateTestDriver)
 import           Test.Tasty.Generator (mkTest)
 import           Test.Tasty.HUnit
 
-case_noModuleSuffixEmptyList :: IO ()
-case_noModuleSuffixEmptyList = do
+unit_noModuleSuffixEmptyList :: IO ()
+unit_noModuleSuffixEmptyList = do
   actual <- findTests "test/SubMod/" (defaultConfig { moduleSuffix = Just "DoesntExist"})
   actual @?= []
 
-case_differentGeneratedModule :: Assertion
-case_differentGeneratedModule = assertBool "" ("FunkyModuleName" `isInfixOf` generatedModule)
+unit_differentGeneratedModule :: Assertion
+unit_differentGeneratedModule = assertBool "" ("FunkyModuleName" `isInfixOf` generatedModule)
   where generatedModule = generateTestDriver "FunkyModuleName" [] "test/" []
 
-case_ignoreAModule :: IO ()
-case_ignoreAModule = do
+unit_ignoreAModule :: IO ()
+unit_ignoreAModule = do
   actual <- findTests "test/SubMod/" (defaultConfig { ignoredModules = ["PropTest"] })
   actual @?= []
 
-case_noModuleSuffix :: IO ()
-case_noModuleSuffix  = do
+unit_noModuleSuffix :: IO ()
+unit_noModuleSuffix  = do
   actual1 <- findTests "test/SubMod/" defaultConfig
   actual1 @?= [mkTest "PropTest" "prop_additionAssociative"]
 

--- a/test/DiscoverTest.hs
+++ b/test/DiscoverTest.hs
@@ -8,8 +8,8 @@ import           Test.Tasty.Hspec
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 
-case_listCompare :: IO ()
-case_listCompare = [1 :: Int, 2, 3] `compare` [1,2] @?= GT
+unit_listCompare :: IO ()
+unit_listCompare = [1 :: Int, 2, 3] `compare` [1,2] @?= GT
 
 prop_additionCommutative :: Int -> Int -> Bool
 prop_additionCommutative a b = a + b == b + a


### PR DESCRIPTION
The deprecation isn't so easy because of the fact that the
clash between duplicate `generatorClass` (see test failure).

Need to make decision there. I'd like to avoid breaking peoples test code.

Remaining things to do:

- [x] Deal with test failure and decision detailed above
- [x] Bump major version ~~and make Hackage release~~

Working on https://github.com/lwm/tasty-discover/issues/95.