### PR TITLE
WIP: Add glob syntax for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Automatic test discovery and runner for the [tasty framework].
 - [Examples](#examples)
 - [Configuration](#configuration)
 - [Change Log](#change-log)
+- [Deprecation Policy](#deprecation-policy)
 - [Contributing](#contributing)
 - [Acknowledgements](#acknowledgements)
 
@@ -100,7 +101,7 @@ Example: `{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --debug #-}`
   - `--debug`: Output the contents of the generated module while testing.
 
 ## With Arguments
-Example: `{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --moduleSuffix=FooBar #-}`
+Example: `{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --module-suffix=FooBar #-}`
 
   - `--module-suffix`: Which test module suffix you wish to have discovered.
   - `--generated-module`: The name of the generated test module.
@@ -109,6 +110,14 @@ Example: `{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --moduleSuffix=FooBar #-
 
 # Change Log
 See the [change log] for the latest changes.
+
+[change log]: https://github.com/lwm/tasty-discover/blob/master/CHANGELOG.md
+
+# Deprecation Policy
+If a breaking change is implemented, you'll see a major version bump, an
+entry in the [change log] and a compile time error with a deprecation
+warning and clear instructions on how to upgrade. Please do complain if we're
+doing this too much.
 
 [change log]: https://github.com/lwm/tasty-discover/blob/master/CHANGELOG.md
 

--- a/library/Test/Tasty/Config.hs
+++ b/library/Test/Tasty/Config.hs
@@ -5,7 +5,6 @@ module Test.Tasty.Config
   , defaultConfig
   ) where
 
-import           Data.Maybe            (isJust)
 import           System.Console.GetOpt (ArgDescr (NoArg, ReqArg),
                                         ArgOrder (Permute), OptDescr (Option),
                                         getOpt)
@@ -25,15 +24,24 @@ data Config = Config
 defaultConfig :: Config
 defaultConfig = Config Nothing Nothing [] [] False False
 
+noModuleSuffixDeprecationMessage :: String
+noModuleSuffixDeprecationMessage =
+  error $ concat
+    [ "\n\n"
+    , "-------------------------------------------------------------------\n"
+    , "DEPRECATION NOTICE: The `--no-module-suffix` option is deprecated.\n"
+    , "Please use the `--module-suffix` with glob syntax.\n"
+    , "Please see https://github.com/lwm/tasty-discover/issues/84.\n"
+    , "-------------------------------------------------------------------\n"
+    ]
+
 -- | Configuration options parser.
 parseConfig :: String -> [String] -> Either String Config
 parseConfig prog args = case getOpt Permute options args of
     (opts, [], []) ->
-      let config   = foldl (flip id) defaultConfig opts
-          errorMsg = "You cannot combine '--no-module-suffix' and '--module-suffix'\n"
-      in
-        if noModuleSuffix config && isJust (moduleSuffix config)
-        then formatError errorMsg
+      let config = foldl (flip id) defaultConfig opts in
+        if noModuleSuffix config
+        then error noModuleSuffixDeprecationMessage
         else Right config
     (_, _, err:_)  -> formatError err
     (_, arg:_, _)  -> formatError ("unexpected argument `" ++ arg ++ "`\n")
@@ -44,21 +52,27 @@ parseConfig prog args = case getOpt Permute options args of
 options :: [OptDescr (Config -> Config)]
 options = [
     Option [] ["module-suffix"]
-      (ReqArg (\s c -> c {moduleSuffix = Just s}) "SUFFIX")
-      "Specify desired test module suffix"
+      -- FIXME: This should be called 'modules' instead
+      (ReqArg (\s c -> c {moduleSuffix = Just s}) "FILE-GLOB")
+      "Specify desired test module suffix via file glob"
   , Option [] ["generated-module"]
       (ReqArg (\s c -> c {generatedModuleName = Just s}) "MODULE")
       "Qualified generated module name"
+
+    -- FIXME: This should be called 'ignores' instead
   , Option [] ["ignore-module"]
-      (ReqArg (\s c -> c {ignoredModules = s : ignoredModules c}) "FILE")
-      "Ignore a test module"
+      (ReqArg (\s c -> s {ignoredModules = Just s}) "FILE-GLOB")
+      "Specify desired test modules to ignore via file glob"
+
   , Option [] ["ingredient"]
       (ReqArg (\s c -> c {tastyIngredients = s : tastyIngredients c}) "INGREDIENT")
       "Qualified tasty ingredient name"
-  , Option [] ["no-module-suffix"]
-      (NoArg $ \c -> c {noModuleSuffix = True})
-      "Ignore test module suffix and import them all"
   , Option [] ["debug"]
       (NoArg $ \c -> c {debug = True})
       "Debug output of generated test module"
+
+  -- DEPRECATED: Use --module-suffix with new glob syntax
+  , Option [] ["no-module-suffix"]
+      (NoArg $ \c -> c {noModuleSuffix = True})
+      "Ignore test module suffix and import them all"
   ]

--- a/library/Test/Tasty/Discover.hs
+++ b/library/Test/Tasty/Discover.hs
@@ -60,17 +60,16 @@ filesBySuffix dir suffixes = do
 isIgnored :: [FilePath] -> String -> Bool
 isIgnored ignores filename = filename `notElem` addSuffixes ignores
 
+filesByModuleGlob :: String -> IO [String]
+filesByModuleGlob dir = undefined
+
 findTests :: FilePath -> Config -> IO [Test]
 findTests src config = do
   let dir      = takeDirectory src
-      suffixes = testFileSuffixes (moduleSuffix config)
-      ignores  = ignoredModules config
-  files <-
-    if noModuleSuffix config
-    then filter isHidden <$> getDirectoryContents dir
-    else filesBySuffix dir suffixes
-  let files' = filter (isIgnored ignores) files
-  concat <$> traverse (extract dir) files'
+      ignores  = fileGlobMatch () dir
+  matchingFiles <- fileGlobMatch pattern dir
+  let filteredFiles = filter (isIgnored ignores) matchingFiles
+  concat <$> traverse (extract dir) filteredFiles
   where
     extract dir file = extractTests file <$> readFile (dir </> file)
 

--- a/library/Test/Tasty/Generator.hs
+++ b/library/Test/Tasty/Generator.hs
@@ -68,8 +68,8 @@ quickCheckPropertyGenerator = Generator
   , generatorSetup  = \t -> "pure $ QC.testProperty \"" ++ name t ++ "\" " ++ qualifyFunction t
   }
 
-deprecationMessage :: String
-deprecationMessage =
+unitPrefixDeprecationMessage :: String
+unitPrefixDeprecationMessage =
   error $ concat
     [ "\n\n"
     , "----------------------------------------------------------\n"
@@ -79,13 +79,13 @@ deprecationMessage =
     , "----------------------------------------------------------\n"
     ]
 
--- DEPRECATED: Use `unit_` instead (below)
+-- DEPRECATED: Use `unit_` instead
 hunitTestCaseGeneratorDeprecated :: Generator
 hunitTestCaseGeneratorDeprecated = Generator
   { generatorPrefix = "case_"
-  , generatorImport = deprecationMessage
-  , generatorClass  = deprecationMessage
-  , generatorSetup  = const deprecationMessage
+  , generatorImport = unitPrefixDeprecationMessage
+  , generatorClass  = unitPrefixDeprecationMessage
+  , generatorSetup  = const unitPrefixDeprecationMessage
   }
 
 hunitTestCaseGenerator :: Generator

--- a/test/ConfigTest.hs
+++ b/test/ConfigTest.hs
@@ -6,26 +6,14 @@ import           Test.Tasty.Discover  (findTests, generateTestDriver)
 import           Test.Tasty.Generator (mkTest)
 import           Test.Tasty.HUnit
 
-unit_noModuleSuffixEmptyList :: IO ()
-unit_noModuleSuffixEmptyList = do
-  actual <- findTests "test/SubMod/" (defaultConfig { moduleSuffix = Just "DoesntExist"})
-  actual @?= []
-
 unit_differentGeneratedModule :: Assertion
-unit_differentGeneratedModule = assertBool "" ("FunkyModuleName" `isInfixOf` generatedModule)
-  where generatedModule = generateTestDriver "FunkyModuleName" [] "test/" []
+unit_differentGeneratedModule =
+  assertBool "" ("FunkyModuleName" `isInfixOf` generatedModule)
+  where
+    generatedModule = generateTestDriver "FunkyModuleName" [] "test/" []
 
 unit_ignoreAModule :: IO ()
 unit_ignoreAModule = do
-  actual <- findTests "test/SubMod/" (defaultConfig { ignoredModules = ["PropTest"] })
+  let config = defaultConfig { ignoredModules = ["PropTest"] }
+  actual <- findTests "test/SubMod/" config
   actual @?= []
-
-unit_noModuleSuffix :: IO ()
-unit_noModuleSuffix  = do
-  actual1 <- findTests "test/SubMod/" defaultConfig
-  actual1 @?= [mkTest "PropTest" "prop_additionAssociative"]
-
-  actual2 <- findTests "test/SubMod/" (defaultConfig { noModuleSuffix = True })
-  let expected = [ mkTest "FooBaz" "prop_additionCommutative"
-                 , mkTest "PropTest" "prop_additionAssociative" ]
-  assertBool "" $ all (`elem` expected) actual2


### PR DESCRIPTION
Nothing to review now, just putting this here to make me remember.

TODO:
  - [ ] Change `--module-suffix` to `--modules` with deprecation notice
  - [ ] Change `--ignore-module` to `--ignores` with deprecation notice
  - [ ] Experiment with [cabal globbing](https://github.com/haskell/cabal/blob/dd0de02be9fb94a19a597fa07b94e6340b538826/Cabal/Distribution/Simple/Utils.hs) or globbing code from https://github.com/lwm/tasty-discover/issues/84 and use one.
  - [ ] Write some tests
    - How to assert that a compile time failure happened? Useful for deprecations!

Something for https://github.com/lwm/tasty-discover/issues/84.