### PR TITLE
Fix directory handling with --no-module-suffix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ install:
   case "$BUILD" in
     cabal)
       cabal update
+      cabal install --dependencies-only --enable-tests
       cabal install
       ;;
     *)

--- a/test/ConfigTest.hs
+++ b/test/ConfigTest.hs
@@ -29,3 +29,8 @@ unit_noModuleSuffix  = do
   let expected = [ mkTest "FooBaz" "prop_additionCommutative"
                  , mkTest "PropTest" "prop_additionAssociative" ]
   assertBool "" $ all (`elem` expected) actual2
+
+unit_noModuleSuffixRecurseDirs :: IO ()
+unit_noModuleSuffixRecurseDirs = do
+  tests <- findTests "test/" (defaultConfig { noModuleSuffix = True })
+  assertBool "" $ elem (mkTest "SubMod/FooBaz" "prop_additionCommutative") tests


### PR DESCRIPTION
When `--no-module-suffix` is set, `findTests` tries to read everything in the test directory as a file. It breaks if you have subdirectories of test modules. E.g. when I add `-optF --no-module-suffix` to this repo's `test/Tasty.hs`, then `stack test`:

```
Preprocessing test suite 'test' for tasty-discover-3.0.0...
tasty-discover: test/SubMod: openFile: inappropriate type (is a directory)
`tasty-discover' failed in phase `Haskell pre-processor'. (Exit code: 1)
```

This PR drops the special handing of `--no-module-suffix`, instead using `""` as the target suffix when that option is set.