### PR TITLE
Add --tree-display flag to orgnanize tests hierarchically

### DIFF
--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -24,7 +24,7 @@ main = do
           tests <- findTests src config
           let ingredients = tastyIngredients config
               moduleName  = fromMaybe "Main" (generatedModuleName config)
-              output      = generateTestDriver moduleName ingredients src tests
+              output      = generateTestDriver config moduleName ingredients src tests
           when (debug config) $ hPutStrLn stderr output
           writeFile dst output
     _ -> do

--- a/library/Test/Tasty/Config.hs
+++ b/library/Test/Tasty/Config.hs
@@ -19,11 +19,12 @@ data Config = Config
   , tastyIngredients    :: [Ingredient]
   , noModuleSuffix      :: Bool
   , debug               :: Bool
+  , moduleTree          :: Bool
   } deriving (Show)
 
 -- | The default configuration
 defaultConfig :: Config
-defaultConfig = Config Nothing Nothing [] [] False False
+defaultConfig = Config Nothing Nothing [] [] False False False
 
 -- | Configuration options parser.
 parseConfig :: String -> [String] -> Either String Config
@@ -61,4 +62,7 @@ options = [
   , Option [] ["debug"]
       (NoArg $ \c -> c {debug = True})
       "Debug output of generated test module"
+  , Option [] ["module-tree"]
+      (NoArg $ \c -> c {moduleTree = True})
+      "Organize test output according module hierarchy"
   ]

--- a/library/Test/Tasty/Config.hs
+++ b/library/Test/Tasty/Config.hs
@@ -19,7 +19,7 @@ data Config = Config
   , tastyIngredients    :: [Ingredient]
   , noModuleSuffix      :: Bool
   , debug               :: Bool
-  , moduleTree          :: Bool
+  , treeDisplay         :: Bool
   } deriving (Show)
 
 -- | The default configuration
@@ -62,7 +62,7 @@ options = [
   , Option [] ["debug"]
       (NoArg $ \c -> c {debug = True})
       "Debug output of generated test module"
-  , Option [] ["module-tree"]
-      (NoArg $ \c -> c {moduleTree = True})
-      "Organize test output according module hierarchy"
+  , Option [] ["tree-display"]
+      (NoArg $ \c -> c {treeDisplay = True})
+      "Display test output hierarchically"
   ]

--- a/library/Test/Tasty/Discover.hs
+++ b/library/Test/Tasty/Discover.hs
@@ -29,7 +29,7 @@ generateTestDriver modname is src tests =
       , "tests = do\n"
       , unlines $ zipWith showSetup tests testNumVars
       , "  pure $ T.testGroup \"" ++ src ++ "\" ["
-      , intercalate "," $ zipWith (curry snd) tests testNumVars
+      , intercalate "," $ showTests tests testNumVars
       , "]\n"
       , concat
         [ "ingredients :: [T.Ingredient]\n"
@@ -97,3 +97,6 @@ ingredientImport = init . dropWhileEnd (/= '.')
 
 ingredients :: [String] -> String
 ingredients is = concat $ map (++":") is ++ ["T.defaultIngredients"]
+
+showTests :: [Test] -> [String] -> [String]
+showTests tests testNumVars = zipWith (curry snd) tests testNumVars

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ extra-source-files:
 
 dependencies:
 - "base       >= 4.8 && < 5"
+- "containers >= 0.4"
 - "directory  >= 1.1 && < 1.4"
 - "filepath   >= 1.3 && < 1.5"
 

--- a/tasty-discover.cabal
+++ b/tasty-discover.cabal
@@ -33,6 +33,7 @@ library
   ghc-options: -Wall
   build-depends:
       base       >= 4.8 && < 5
+    , containers >= 0.4
     , directory  >= 1.1 && < 1.4
     , filepath   >= 1.3 && < 1.5
   exposed-modules:
@@ -46,6 +47,7 @@ executable tasty-discover
   ghc-options: -Wall
   build-depends:
       base       >= 4.8 && < 5
+    , containers >= 0.4
     , directory  >= 1.1 && < 1.4
     , filepath   >= 1.3 && < 1.5
     , tasty-discover
@@ -59,6 +61,7 @@ test-suite test
   ghc-options: -Wall
   build-depends:
       base       >= 4.8 && < 5
+    , containers >= 0.4
     , directory  >= 1.1 && < 1.4
     , filepath   >= 1.3 && < 1.5
     , base

--- a/test/ConfigTest.hs
+++ b/test/ConfigTest.hs
@@ -2,7 +2,7 @@ module ConfigTest where
 
 import           Data.List            (isInfixOf)
 import           Test.Tasty.Config
-import           Test.Tasty.Discover  (findTests, generateTestDriver)
+import           Test.Tasty.Discover  (findTests, generateTestDriver, showTests)
 import           Test.Tasty.Generator (mkTest)
 import           Test.Tasty.HUnit
 
@@ -27,5 +27,20 @@ unit_noModuleSuffix  = do
 
   actual2 <- findTests "test/SubMod/" (defaultConfig { noModuleSuffix = True })
   let expected = [ mkTest "FooBaz" "prop_additionCommutative"
+                 , mkTest "FooBaz" "prop_multiplationDistributiveOverAddition"
                  , mkTest "PropTest" "prop_additionAssociative" ]
   assertBool "" $ all (`elem` expected) actual2
+
+unit_noModuleTreeDefault :: IO ()
+unit_noModuleTreeDefault = do
+  tests <- findTests "test/SubMod/" (defaultConfig { noModuleSuffix = True })
+  let testNumVars = map (('t' :) . show) [(0::Int)..]
+      trees = showTests tests testNumVars
+  length trees @?= 3
+
+unit_moduleTree :: IO ()
+unit_moduleTree = do
+  tests <- findTests "test/SubMod/" (defaultConfig { noModuleSuffix = True })
+  let testNumVars = map (('t' :) . show) [(0::Int)..]
+      trees = showTests tests testNumVars
+  length trees @?= 2

--- a/test/ConfigTest.hs
+++ b/test/ConfigTest.hs
@@ -1,10 +1,14 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module ConfigTest where
 
 import           Data.List            (isInfixOf)
+import qualified Data.Map.Strict      as M
 import           Test.Tasty.Config
-import           Test.Tasty.Discover  (findTests, generateTestDriver, showTests)
-import           Test.Tasty.Generator (mkTest)
+import           Test.Tasty.Discover  (findTests, generateTestDriver, showTests,
+                                       ModuleTree(..), mkModuleTree)
+import           Test.Tasty.Generator (Test(..), mkTest)
 import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
 
 unit_noModuleSuffixEmptyList :: IO ()
 unit_noModuleSuffixEmptyList = do
@@ -13,7 +17,7 @@ unit_noModuleSuffixEmptyList = do
 
 unit_differentGeneratedModule :: Assertion
 unit_differentGeneratedModule = assertBool "" ("FunkyModuleName" `isInfixOf` generatedModule)
-  where generatedModule = generateTestDriver "FunkyModuleName" [] "test/" []
+  where generatedModule = generateTestDriver defaultConfig "FunkyModuleName" [] "test/" []
 
 unit_ignoreAModule :: IO ()
 unit_ignoreAModule = do
@@ -31,16 +35,40 @@ unit_noModuleSuffix  = do
                  , mkTest "PropTest" "prop_additionAssociative" ]
   assertBool "" $ all (`elem` expected) actual2
 
-unit_noModuleTreeDefault :: IO ()
-unit_noModuleTreeDefault = do
-  tests <- findTests "test/SubMod/" (defaultConfig { noModuleSuffix = True })
+unit_noTreeDisplayDefault :: IO ()
+unit_noTreeDisplayDefault = do
+  let config = defaultConfig { noModuleSuffix = True }
+  tests <- findTests "test/SubMod/" config
   let testNumVars = map (('t' :) . show) [(0::Int)..]
-      trees = showTests tests testNumVars
+      trees = showTests config tests testNumVars
   length trees @?= 3
 
-unit_moduleTree :: IO ()
-unit_moduleTree = do
-  tests <- findTests "test/SubMod/" (defaultConfig { noModuleSuffix = True })
+unit_treeDisplay :: IO ()
+unit_treeDisplay = do
+  let config = defaultConfig { noModuleSuffix = True, treeDisplay = True }
+  tests <- findTests "test/SubMod/" config
   let testNumVars = map (('t' :) . show) [(0::Int)..]
-      trees = showTests tests testNumVars
+      trees = showTests config tests testNumVars
   length trees @?= 2
+
+prop_mkModuleTree :: ModuleTree -> Property
+prop_mkModuleTree mtree =
+    let (tests, testVars) = unzip $ flattenTree mtree
+    in mkModuleTree tests testVars === mtree
+  where
+    flattenTree (ModuleTree mp) = M.assocs mp >>= flattenModule
+    flattenModule (mdl, (subTree, testVars)) = concat
+      [ map (\((Test subMdl _), tVar) -> (Test (mdl ++ '.':subMdl) "-", tVar)) (flattenTree subTree)
+      , map (\tVar -> (Test mdl "-", tVar)) testVars ]
+
+instance Arbitrary ModuleTree where
+  arbitrary = sized $ \size ->
+      resize (min size 12) (ModuleTree . M.fromList <$> listOf1 mdlGen)
+    where
+      mdlGen = sized $ \size -> do
+        mdl <- listOf1 (elements ['a'..'z'])
+        subTree <- if size == 0
+          then pure $ ModuleTree M.empty
+          else resize (size `div` 2) arbitrary
+        tVars <- listOf1 (listOf1 arbitrary)
+        pure (mdl, (subTree, tVars))

--- a/test/SubMod/FooBaz.hs
+++ b/test/SubMod/FooBaz.hs
@@ -2,3 +2,6 @@ module SubMod.FooBaz where
 
 prop_additionCommutative :: Int -> Int -> Bool
 prop_additionCommutative a b = a + b == b + a
+
+prop_multiplationDistributiveOverAddition :: Integer -> Integer -> Integer -> Bool
+prop_multiplationDistributiveOverAddition a b c = a * (b + c) == a * b + a * c


### PR DESCRIPTION
A batteries-included feature request 😄 

This adds a `--tree-display` flag to display tests according to the module structure. Hierarchical display is helpful when working with larger test suites.

E.g. when used on this repo, test output looks like

```
test/Tasty.hs
  ConfigTest
    noModuleSuffixEmptyList:                 OK
    differentGeneratedModule:                OK
    ignoreAModule:                           OK
    noModuleSuffix:                          OK
    noTreeDisplayDefault:                    OK
    treeDisplay:                             OK
    mkModuleTree:                            OK (0.16s)
      +++ OK, passed 100 tests.
  DiscoverTest
    listCompare:                             OK
    additionCommutative:                     OK
      +++ OK, passed 100 tests.
    prelude
      Prelude.head
        returns the first element of a list: OK
    Addition commutes:                       OK
      +++ OK, passed 100 tests.
    multiplication
      Multiplication commutes:               OK
        +++ OK, passed 100 tests.
      One is identity:                       OK
        +++ OK, passed 100 tests.
    Some input:                              OK
    generateTrees
      First input:                           OK
      Second input:                          OK
  SubMod.PropTest
    additionAssociative:                     OK
      +++ OK, passed 100 tests.

All 17 tests passed (0.17s)
```