### PR TITLE
Fix rendering of CHANGELOG for Hackage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,23 @@ The format is based on [Keep a Changelog] and this project adheres to
 [Keep a Changelog]: http://keepachangelog.com/
 [Semantic Versioning]: http://semver.org/
 
+# 3.0.1 [UNRELEASED]
+
+### Fixed
+- Fixed CHANGELOG.md rendering for Hackage (see pull request [#106]).
+
+[#106]: https://github.com/lwm/tasty-discover/pull/106
+
 # 3.0.0 2017-05-03
 
 ### Added
-- [#103]: Added `--tree-display` configuration option.
+- Added --tree-display configuration option (see pull request [#103]).
 
 ### Changed
-- [#97]: `case_` is deprecated in favour of `unit_` for HUnit test cases.
+- Deprecate case_ in favour of unit_ for HUnit test cases (see pull request [#97]).
 
 ### Fixed
-- [#102]: `--no-module-suffix` incorrectly handling directories.
+- Correctly handle sub-directories when using --no-module-suffix (see pull request [#102]).
 
 [#97]: https://github.com/lwm/tasty-discover/pull/97
 [#102]: https://github.com/lwm/tasty-discover/pull/102
@@ -31,11 +38,8 @@ The format is based on [Keep a Changelog] and this project adheres to
 # 2.0.2 [2017-04-13]
 
 ### Added
-- Change log is in `extra-source-files` now.
-- [#96]: README is in `extra-source-files` now.
-
-### Fixed
-- [#88]: stylish-haskell automated checking.
+- README.md and CHANGELOG.md included for Hackage (see pull request [#96]).
+- Re-added stylish-haskell automated checking (see pull request [#88]).
 
 [#88]: https://github.com/lwm/tasty-discover/pull/88
 [#96]: https://github.com/lwm/tasty-discover/pull/96
@@ -43,22 +47,22 @@ The format is based on [Keep a Changelog] and this project adheres to
 ## 2.0.1 [2017-03-18]
 
 ### Fixed
-- [#86]: Flaky test comparison.
+- Fix flaky test comparison (see pull request [#86]).
 
 [#86]: https://github.com/lwm/tasty-discover/pull/86
 
 ### Removed
-- [#83]: The `Test.Tasty.Type` module.
+- Remove the Test.Tasty.Type module (see pull request [#83]).
 
 [#83]: https://github.com/lwm/tasty-discover/pull/83
 
 ## 2.0.0 [2017-03-15]
 
 ### Added
-- Use hpack format.
-- Use generator style test discovery from tasty-auto.
-- New configuration options: debug, ingredients and module name.
-- Unit tests for all functionality.
+- Add new hpack format.
+- Add generator style test discovery from tasty-auto.
+- Add new configuration options: debug, ingredients and module name.
+- Add unit tests for all functionality.
 
 ### Fixed
 - Re-license to MIT.
@@ -74,33 +78,33 @@ The format is based on [Keep a Changelog] and this project adheres to
 ## 1.1.0 [2017-01-19]
 
 ### Added
-- `--ignore-module` configuration option.
+- Add --ignore-module configuration option.
 
 ## 1.0.1 [2017-11-13]
 
 ### Added
-- Cabal testing on Travis CI.
-- Documentation testing on Travis CI.
+- Add Cabal and Documentation testing on Travis CI.
 
 ### Fixed
-- Include missing `extra-source-files`.
+- Include missing extra-source-files.
 - Slim down LICENSE.md and mark as GPL-3 in Cabal file.
 
 ## 1.0.0 [2016-11-04]
 
 ### Added
-- Documentation to RTD.
+- Add documentation on RTD.
 - Release on Hackage and Stackage.
 
 ## 0.0.3 [2016-09-20]
 
 ### Added
-- `--no-module-suffix` configuration option.
+- --no-module-suffix configuration option.
 
 ## 0.0.2 [2016-02-20]
 
 ### Added
-- `--module-suffix` configuration option.
+- --module-suffix configuration option.
 
 ## 0.0.1 [2016-02-13]
+
 - tasty-discover initial release.


### PR DESCRIPTION
By adding `[FOO]:` at the start of the line, the file rendering
was being borked. I've added them to the end of the line now.

Closes https://github.com/lwm/tasty-discover/issues/104.