### PR TITLE
Find test modules recursively (broken in 4.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog] and this project adheres to
 
 # X.X.X [UNRELEASED]
 
+## Fixed
+- Find tests recursively in test directory.
+
 ## Added
 - Add ability to override tasty arguments (see pull request [#120]).
 
@@ -25,7 +28,7 @@ The format is based on [Keep a Changelog] and this project adheres to
 - `tasty-hedgehog` is now a supported test library.
 
 ## Removed
-- `unit_` prefixes have been removed.
+- `case_` prefixes have been removed.
 
 [#117]: https://github.com/lwm/tasty-discover/pull/117
 

--- a/tasty-discover.cabal
+++ b/tasty-discover.cabal
@@ -83,4 +83,5 @@ test-suite test
       DiscoverTest
       SubMod.FooBaz
       SubMod.PropTest
+      SubMod.SubSubMod.PropTest
   default-language: Haskell2010

--- a/test/ConfigTest.hs
+++ b/test/ConfigTest.hs
@@ -17,10 +17,11 @@ spec_modules :: Spec
 spec_modules =
   describe "Test discovery" $
   it "Discovers tests" $ do
-    let expectedTest = mkTest "PropTest" "prop_additionAssociative"
-        config       = defaultConfig { modules = Just "*Test.hs" }
+    let expectedTests = [ mkTest "PropTest.hs" "prop_additionAssociative",
+                          mkTest "SubSubMod/PropTest.hs" "prop_additionCommutative" ]
+        config        = defaultConfig { modules = Just "*Test.hs" }
     discoveredTests <- findTests "test/SubMod/" config
-    discoveredTests `shouldBe` [expectedTest]
+    discoveredTests `shouldBe` expectedTests
 
 spec_ignores :: Spec
 spec_ignores =
@@ -50,7 +51,7 @@ unit_noTreeDisplayDefault = do
   tests <- findTests "test/SubMod/" defaultConfig
   let testNumVars = map (('t' :) . show) [(0::Int)..]
       trees = showTests defaultConfig tests testNumVars
-  length trees @?= 3
+  length trees @?= 4
 
 unit_treeDisplay :: IO ()
 unit_treeDisplay = do
@@ -58,7 +59,7 @@ unit_treeDisplay = do
   tests <- findTests "test/SubMod/" config
   let testNumVars = map (('t' :) . show) [(0::Int)..]
       trees = showTests config tests testNumVars
-  length trees @?= 2
+  length trees @?= 3
 
 prop_mkModuleTree :: ModuleTree -> Property
 prop_mkModuleTree mtree =

--- a/test/SubMod/SubSubMod/PropTest.hs
+++ b/test/SubMod/SubSubMod/PropTest.hs
@@ -1,0 +1,4 @@
+module SubMod.SubSubMod.PropTest where
+
+prop_additionCommutative :: Int -> Int -> Bool
+prop_additionCommutative a b = a + b == b + a


### PR DESCRIPTION
This fixes a bug introduced in 557ff352c846867490726d8f88fbe7e77695eee6/`4.0.0` where tests are only found in files adjacent to the driver module, not recursively in adjacent directories. I've updated the relevant spec to test for this explicitly.

Also updated `CHANGELOG.md` to say `_case` prefixes have been removed, not `_unit`.