### PR TITLE
Add test for Windows with AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+# Disabled cache in hope of improving reliability of AppVeyor builds
+#cache:
+#- "c:\\sr" # stack root, short paths == fewer problems
+
+build: off
+
+before_test:
+# http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
+- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
+- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
+- 7z x stack.zip stack.exe
+
+clone_folder: "c:\\stack"
+environment:
+  global:
+    STACK_ROOT: "c:\\sr"
+
+test_script:
+- stack setup > nul
+# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
+# descriptor
+- echo "" | stack --no-terminal install --jobs 1
+- echo "" | stack --no-terminal test --jobs 1

--- a/library/Test/Tasty/Generator.hs
+++ b/library/Test/Tasty/Generator.hs
@@ -26,7 +26,7 @@ module Test.Tasty.Generator
 import           Data.Function   (on)
 import           Data.List       (find, groupBy, isPrefixOf, sortOn)
 import           Data.Maybe      (fromJust)
-import           System.FilePath (dropExtension, pathSeparator)
+import           System.FilePath (dropExtension, isPathSeparator)
 
 -- | The test type.
 data Test = Test
@@ -36,8 +36,8 @@ data Test = Test
 
 -- | 'Test' constructor.
 mkTest :: FilePath -> String -> Test
-mkTest = Test . chooser pathSeparator '.' . dropExtension
-  where chooser c1 c2 = map $ \c3 -> if c3 == c1 then c2 else c3
+mkTest = Test . replacePathSepTo '.' . dropExtension
+  where replacePathSepTo c1 = map $ \c2 -> if isPathSeparator c2 then c1 else c2
 
 -- | The generator type.
 data Generator = Generator


### PR DESCRIPTION
about #127 
I wrote `appveyor.yml` with reference to [this file](https://github.com/commercialhaskell/stack/blob/a6ae6a51e1b0b12c37786c27bdd3e0a7e9497c03/appveyor.yml).

but, test fail on Windows:
https://ci.appveyor.com/project/matsubara0507/tasty-discover/build/1.0.5#L473
```
modules
    Test discovery
      Discovers tests:                                           FAIL
        expected [Test {testModule = "PropTest", testFunction = "prop_additionAssociative"},Test {testModule = "SubSubMod/PropTest", testFunction = "prop_additionCommutative"}], but got [Test {testModule = "PropTest", testFunction = "prop_additionAssociative"},Test {testModule = "SubSubMod.PropTest", testFunction = "prop_additionCommutative"}]
```  

Reason is that use `pathSeparator` on `mkTest` .
So, fixed it by using [`isPathSeparator`](https://hackage.haskell.org/package/filepath-1.4.2/docs/System-FilePath-Windows.html#v:isPathSeparator) .
ref: https://ci.appveyor.com/project/matsubara0507/tasty-discover/build/1.0.6