### PR TITLE
Avoid errors on non UTF-8 Windows

### DIFF
--- a/library/Test/Tasty/Discover.hs
+++ b/library/Test/Tasty/Discover.hs
@@ -19,8 +19,10 @@ import           Data.Maybe               (fromMaybe)
 #if defined(mingw32_HOST_OS)
 import           GHC.IO.Encoding.CodePage (mkLocaleEncoding)
 import           GHC.IO.Encoding.Failure  (CodingFailureMode (TransliterateCodingFailure))
-#endif
 import           GHC.IO.Handle            (hGetContents, hSetEncoding)
+#else
+import           GHC.IO.Handle            (hGetContents)
+#endif
 import           System.FilePath          (pathSeparator, takeDirectory)
 import           System.FilePath.Glob     (compile, globDir1, match)
 import           System.IO                (IOMode (ReadMode), openFile)


### PR DESCRIPTION
about #135 but **not file path, error is occur if the file contents includes multibyte strings** (e.g. Japanese). 

This problem like haddoc issue https://github.com/haskell/haddock/pull/566 .

## Environment
OS: Windows 10
tasty-discover: 4.1.3 
GHC: 8.2.2

```
> stack test
tasty-discover-4.1.3: build (lib + exe + test)
Preprocessing library for tasty-discover-4.1.3..
Building library for tasty-discover-4.1.3..
Preprocessing executable 'tasty-discover' for tasty-discover-4.1.3..
Building executable 'tasty-discover' for tasty-discover-4.1.3..
Preprocessing test suite 'test' for tasty-discover-4.1.3..
Building test suite 'test' for tasty-discover-4.1.3..
tasty-discover: test\ConfigTest.hs: hGetContents: invalid argument (invalid byte sequence)
`tasty-discover' failed in phase `Haskell pre-processor'. (Exit code: 1)
Progress: 1/2
--  While building custom Setup.hs for package tasty-discover-4.1.3 using:
      C:\Users\Hoge\AppData\Roaming\stack\setup-exe-cache\i386-windows\Cabal-simple_Z6RU0evB_2.0.1.0_ghc-8.2.2.exe --builddir=.stack-work\dist\010ee936 build lib:tasty-discover exe:tasty-discover test:test --ghc-options " -ddump-hi -ddump-to-file -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1
```

I fixed this problem, but I have not idea how to test this case.
Because, tasty-discover's test use tasty-discover .