### PR TITLE
Added test generator for SmallCheck

### DIFF
--- a/library/Test/Tasty/Generator.hs
+++ b/library/Test/Tasty/Generator.hs
@@ -78,6 +78,7 @@ showSetup t var = "  " ++ var ++ " <- " ++ setup ++ "\n"
 generators :: [Generator]
 generators =
   [ quickCheckPropertyGenerator
+  , smallCheckPropertyGenerator
   , hedgehogPropertyGenerator
   , hunitTestCaseGenerator
   , hspecTestCaseGenerator
@@ -100,6 +101,15 @@ quickCheckPropertyGenerator = Generator
   , generatorImport = "import qualified Test.Tasty.QuickCheck as QC\n"
   , generatorClass  = ""
   , generatorSetup  = \t -> "pure $ QC.testProperty \"" ++ name t ++ "\" " ++ qualifyFunction t
+  }
+
+-- | Smallcheck group generator prefix.
+smallCheckPropertyGenerator :: Generator
+smallCheckPropertyGenerator = Generator
+  { generatorPrefix = "scprop_"
+  , generatorImport = "import qualified Test.Tasty.SmallCheck as SC\n"
+  , generatorClass  = ""
+  , generatorSetup  = \t -> "pure $ SC.testProperty \"" ++ name t ++ "\" " ++ qualifyFunction t
   }
 
 -- | HUnit generator prefix.


### PR DESCRIPTION
Fix #140 

No changed any test code.

### before (tasty-discover-4.1.5)

<img width="635" alt="2018-03-03 11 42 04" src="https://user-images.githubusercontent.com/31357/36929697-048d197e-1ed8-11e8-89dd-477b8724fa08.png">

### after

<img width="655" alt="2018-03-03 11 42 21" src="https://user-images.githubusercontent.com/31357/36929700-18be8f86-1ed8-11e8-8ef7-66d39121bc6b.png">

tasty-discover become able to lookup test function with `scprop_` prefix, generate `tasty-smallcheck` 's testProperty.
